### PR TITLE
Update job lifecycle document to reflect switchboard changes

### DIFF
--- a/src/internals/job_lifecycle.md
+++ b/src/internals/job_lifecycle.md
@@ -183,7 +183,7 @@ enum ExitStatus {
     /// The job timed out while dispatched.
     ///
     /// **This exit status is final. No subsequently reported exit status may
-    /// override this status.
+    /// override this status.**
     JobTimeout,
 }
 ```


### PR DESCRIPTION
Accompanying recent updates to treadmill-tb/treadmill#58; update job lifecycle document to match actual usage.

Pending acceptance of treadmill-tb/treadmill#58.